### PR TITLE
build(webpack): fix webpack build error

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,8 +1,10 @@
+const path = require('path');
+
 export default () => (
     {
         entry: './index.js',
         output: {
-            path: './dist',
+            path: path.resolve(__dirname, './dist'),
             filename: 'webpack-numbers.js',
             libraryTarget: 'umd',
             library: 'webpackNumbers'


### PR DESCRIPTION
Fixes build error with latest webpack:

```bash
webpack && cp dist/webpack-numbers.js examples/browser
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.output.path: The provided value "./dist" is not an absolute path!
```